### PR TITLE
Fix the markup of the installation section in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The library comes with text samples used for training and detecting text in 106 
 
 ## Installation with Composer
 > **Note:** This library requires the [Multibyte String](http://php.net/manual/en/book.mbstring.php) extension in order to work. 
+
 ```bash
 $ composer require patrickschur/language-detection
 ```


### PR DESCRIPTION
the code-block showing the composer instruction should not be inside the note about needing mbstring.