### PR TITLE
Use count($samples) instead of $this->maxNgrams

### DIFF
--- a/src/LanguageDetection/Language.php
+++ b/src/LanguageDetection/Language.php
@@ -63,10 +63,11 @@ class Language extends NgramParser
         $str = mb_strtolower($str);
 
         $samples = $this->getNgrams($str);
+        $sample_count = count($samples);
 
         $result = [];
 
-        if (count($samples) > 0)
+        if ( $sample_count > 0)
         {
             foreach ($this->tokens as $lang => $value)
             {
@@ -83,11 +84,11 @@ class Language extends NgramParser
                         continue;
                     }
 
-                    $sum += $this->maxNgrams;
+                    $sum += $sample_count;
                     ++$index;
                 }
 
-                $result[$lang] = 1 - ($sum / ($this->maxNgrams * $index));
+                $result[$lang] = 1 - ($sum / ($sample_count * $index));
             }
 
             arsort($result, SORT_NUMERIC);


### PR DESCRIPTION
Just an idea. Increasing the size of maxNgrams will change the result confidences even if there's no actual difference. Using count($samples), we would get the same result if maxNgrams is set to 10,000 or 100,000.