### PR TITLE
Fix Unsupported operand types for custom directory

### DIFF
--- a/src/LanguageDetection/Language.php
+++ b/src/LanguageDetection/Language.php
@@ -38,7 +38,7 @@ class Language extends NgramParser
         else
         {
             $dirname = \rtrim($dirname, '/');
-            $dirname .= '/*/*.json';
+            $dirname .= '/*/*.php';
         }
 
         $isEmpty = empty($lang);


### PR DESCRIPTION
A custom directory will lead to the library not working because the .json file is requested in the $dirname instead of the .php file.

So until this fixed as proposed, 4.0 will not work for anyone using a custom directory.