### PR TITLE
PHP 8.4 Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Array
 ```
 <hr style="background-color:#666"/>
 
-#### `limit(int $offset, int $length = null)`
+#### `limit(int $offset, ?int $length = null)`
 You can specify the number of records to return. For example the following code will return the top three entries.
 ```php
 $ld->detect('Mag het een onsje meer zijn?')->limit(0, 3)->close();

--- a/src/LanguageDetection/LanguageResult.php
+++ b/src/LanguageDetection/LanguageResult.php
@@ -142,7 +142,7 @@ class LanguageResult implements \JsonSerializable, \IteratorAggregate, \ArrayAcc
      * @param int|null $length
      * @return LanguageResult
      */
-    public function limit(int $offset, int $length = null): LanguageResult
+    public function limit(int $offset, ?int $length = null): LanguageResult
     {
         return new LanguageResult(\array_slice($this->result, $offset, $length));
     }


### PR DESCRIPTION
Implicitly marking parameter as nullable is deprecated in PHP 8.4.

Fixed by explicitly marking the parameter as nullable.